### PR TITLE
optimization for annotations visualization data load

### DIFF
--- a/sites/all/modules/custom/lacuna_visualizations/lacuna_visualizations.module
+++ b/sites/all/modules/custom/lacuna_visualizations/lacuna_visualizations.module
@@ -619,8 +619,10 @@ function lacuna_visualizations_annotation_dashboard_data() {
   $documentNames = array(); // to cut down on db queries
   $userNames = array();   // same as previous - only load users once
   $annotations = array();
-  foreach (array_keys($result['node']) as $nid) {
-    $annotation = node_load($nid);
+  $allNodes = node_load_multiple(array_keys($result['node']));  // instead of loading one by one, do a batch load
+//  foreach (array_keys($result['node']) as $nid) {
+//    $annotation = node_load($nid);
+    foreach($allNodes as $annotation){
     // Create a new data object, populate only with necessary data
     // Make it harder to leak unintended data
     $data = new StdClass();


### PR DESCRIPTION
It turned out that the bottleneck of the annotations visualization data load function was the point where thousands of annotations were loaded one by one. After changing that with a one time multiple_load some the total execution time of that function reduced more than 5 times (from 4.2s to 0.8s, for 1048 annotations).
