### PR TITLE
Scrolling to annotator autocomplete box

### DIFF
--- a/sites/all/modules/custom/annotator/css/tags.css
+++ b/sites/all/modules/custom/annotator/css/tags.css
@@ -1,3 +1,11 @@
+/*  Tag autocomplete box set to 10 lines tall with scroll
+*   activated for overflow.
+*/
+.ui-autocomplete {
+  height: 10em;
+  overflow: scroll;
+}
+
 .ui-autocomplete-category {
   font-weight: bold;
   border-bottom: 1px solid black;


### PR DESCRIPTION
Set CSS properties for annotator tag autocomplete box to limit box height and enable scroll for overflow.
