### PR TITLE
2 changes to content type course

### DIFF
--- a/sites/all/modules/custom/course/course.features.field_instance.inc
+++ b/sites/all/modules/custom/course/course.features.field_instance.inc
@@ -40,7 +40,7 @@ function course_field_default_field_instances() {
     'required' => 0,
     'settings' => array(
       'display_summary' => 1,
-      'text_processing' => 1,
+      'text_processing' => 0,
       'user_register_form' => FALSE,
     ),
     'widget' => array(
@@ -114,7 +114,7 @@ function course_field_default_field_instances() {
         'module' => 'image',
         'settings' => array(
           'image_link' => '',
-          'image_style' => 'large',
+          'image_style' => '',
         ),
         'type' => 'image',
         'weight' => 0,
@@ -861,9 +861,8 @@ function course_field_default_field_instances() {
     'display' => array(
       'default' => array(
         'label' => 'above',
-        'module' => 'list',
         'settings' => array(),
-        'type' => 'list_default',
+        'type' => 'hidden',
         'weight' => 19,
       ),
       'teaser' => array(
@@ -1057,6 +1056,12 @@ function course_field_default_field_instances() {
         'type' => 'og_list_default',
         'weight' => 0,
       ),
+      'full' => array(
+        'label' => 'above',
+        'settings' => array(),
+        'type' => 'hidden',
+        'weight' => 0,
+      ),
     ),
     'entity_type' => 'user',
     'field_name' => 'og_user_node',
@@ -1111,6 +1116,12 @@ function course_field_default_field_instances() {
         'settings' => array(),
         'type' => 'og_list_default',
         'weight' => 10,
+      ),
+      'full' => array(
+        'label' => 'above',
+        'settings' => array(),
+        'type' => 'hidden',
+        'weight' => 0,
       ),
     ),
     'entity_type' => 'user',


### PR DESCRIPTION
1) Image appearing on course info page is no longer style "large" but "none," allowing higher image quality
2) The field "course description" now only allows plain text (as opposed to filtered html), allowing us to avoid formatting problems like the one we find on the current Berkeley site