### PR TITLE
Fixed console errors on annotation dashboard

### DIFF
--- a/sites/all/modules/custom/lacuna_visualizations/libraries/d3.annotations_dashboard/annotations_dashboard.js
+++ b/sites/all/modules/custom/lacuna_visualizations/libraries/d3.annotations_dashboard/annotations_dashboard.js
@@ -814,6 +814,9 @@ function main(data) {
 		});
 		var g = dim.group();
 		var data = fill_empty_dates(g.all());
+		
+		// Only display every other label
+		for (var i = 0; i < data.length; i++) data.splice(i, 1);
 
 		if (bar_chart === null) {
 			bar_chart = d3.select("div#time_brush").append("svg")
@@ -829,10 +832,7 @@ function main(data) {
 			xAxis = d3.svg.axis()
 		    .scale(bar_x)
 		    .orient("bottom")
-		    // Only display every other label
-		    .tickValues(data.map(function (d,i) {
-		    	if (i % 7 === 0) { return d.x}
-		    }))
+		    .ticks(10)
 			;
 
   		bar_chart.append("g")


### PR DESCRIPTION
...that were caused by explicitly setting tick values to non-integers.  I'm not totally sure why this fix works, but it seems like it goes along with the D3 paradigm a little better, and it does what the "Only displays every other label" comment suggests the intent of the code was.