### PR TITLE
Annotations dashboard fix, try 2

### DIFF
--- a/sites/all/modules/custom/lacuna_visualizations/libraries/d3.annotations_dashboard/annotations_dashboard.js
+++ b/sites/all/modules/custom/lacuna_visualizations/libraries/d3.annotations_dashboard/annotations_dashboard.js
@@ -814,9 +814,6 @@ function main(data) {
 		});
 		var g = dim.group();
 		var data = fill_empty_dates(g.all());
-		
-		// Only display every other label
-		for (var i = 0; i < data.length; i++) data.splice(i, 1);
 
 		if (bar_chart === null) {
 			bar_chart = d3.select("div#time_brush").append("svg")
@@ -832,7 +829,11 @@ function main(data) {
 			xAxis = d3.svg.axis()
 		    .scale(bar_x)
 		    .orient("bottom")
-		    .ticks(10)
+		    .ticks(null)
+		    .tickFormat(function(d, i) {
+		    	if (data.length > 30) return i % 7 === 0 ? d : '';
+		    	else return d;
+		    });
 			;
 
   		bar_chart.append("g")

--- a/sites/all/modules/custom/lacuna_visualizations/libraries/d3.annotations_dashboard/annotations_dashboard.js
+++ b/sites/all/modules/custom/lacuna_visualizations/libraries/d3.annotations_dashboard/annotations_dashboard.js
@@ -831,6 +831,8 @@ function main(data) {
 		    .orient("bottom")
 		    .ticks(null)
 		    .tickFormat(function(d, i) {
+		    	/*	Displays ticks by week if there are too many to
+		    	*	clearly display.   */
 		    	if (data.length > 30) return i % 7 === 0 ? d : '';
 		    	else return d;
 		    });

--- a/sites/all/themes/lacuna_stories/js/annotations_dashboard_viewport.js
+++ b/sites/all/themes/lacuna_stories/js/annotations_dashboard_viewport.js
@@ -22,7 +22,7 @@ Drupal.behaviors.annotator_dashboard = {
    if (window.location.pathname.indexOf('/visualization/dashboard') > -1 && window.innerWidth < 1215) {
 
     var meta_viewport = document.querySelector('head meta[name="viewport"]');
-    meta_viewport.content = "width=1215px";
+    meta_viewport.content = "width=1215";
 
    }
   }


### PR DESCRIPTION
Set "Filter by Time" ticks to appear by week if there are over 30 days of annotations, plus fixed a viewport-related console warning.