### PR TITLE
Fixed clean install permissions

### DIFF
--- a/sites/all/modules/features/lacuna_stories_materials/lacuna_stories_materials.info
+++ b/sites/all/modules/features/lacuna_stories_materials/lacuna_stories_materials.info
@@ -97,6 +97,7 @@ features[variable][] = comment_document
 features[variable][] = comment_form_location_document
 features[variable][] = comment_preview_document
 features[variable][] = comment_subject_field_document
+features[variable][] = content_access_document
 features[variable][] = field_bundle_settings_node__document
 features[variable][] = menu_options_document
 features[variable][] = menu_parent_document

--- a/sites/all/modules/features/lacuna_stories_materials/lacuna_stories_materials.strongarm.inc
+++ b/sites/all/modules/features/lacuna_stories_materials/lacuna_stories_materials.strongarm.inc
@@ -154,6 +154,25 @@ function lacuna_stories_materials_strongarm() {
   $strongarm = new stdClass();
   $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
   $strongarm->api_version = 1;
+  $strongarm->name = 'content_access_document';
+  $strongarm->value = array(
+    'view_own' => array(
+      0 => 2,
+      1 => 5,
+      2 => 3,
+    ),
+    'view' => array(
+      0 => 2,
+      1 => 5,
+      2 => 3,
+    ),
+    'priority' => '-5',
+  );
+  $export['content_access_document'] = $strongarm;
+
+  $strongarm = new stdClass();
+  $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
+  $strongarm->api_version = 1;
   $strongarm->name = 'pathauto_taxonomy_term_copyright_status_pattern';
   $strongarm->value = '';
   $export['pathauto_taxonomy_term_copyright_status_pattern'] = $strongarm;

--- a/sites/all/modules/features/lacuna_stories_materials/lacuna_stories_materials.strongarm.inc
+++ b/sites/all/modules/features/lacuna_stories_materials/lacuna_stories_materials.strongarm.inc
@@ -62,6 +62,24 @@ function lacuna_stories_materials_strongarm() {
   $strongarm = new stdClass();
   $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
   $strongarm->api_version = 1;
+  $strongarm->name = 'content_access_document';
+  $strongarm->value = array(
+    'view_own' => array(
+      0 => 2,
+      1 => 5,
+      2 => 3,
+    ),
+    'view' => array(
+      0 => 2,
+      1 => 5,
+      2 => 3,
+    ),
+  );
+  $export['content_access_document'] = $strongarm;
+
+  $strongarm = new stdClass();
+  $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
+  $strongarm->api_version = 1;
   $strongarm->name = 'field_bundle_settings_node__document';
   $strongarm->value = array(
     'view_modes' => array(
@@ -150,25 +168,6 @@ function lacuna_stories_materials_strongarm() {
   $strongarm->name = 'pathauto_node_document_pattern';
   $strongarm->value = 'document/[node:title]';
   $export['pathauto_node_document_pattern'] = $strongarm;
-
-  $strongarm = new stdClass();
-  $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
-  $strongarm->api_version = 1;
-  $strongarm->name = 'content_access_document';
-  $strongarm->value = array(
-    'view_own' => array(
-      0 => 2,
-      1 => 5,
-      2 => 3,
-    ),
-    'view' => array(
-      0 => 2,
-      1 => 5,
-      2 => 3,
-    ),
-    'priority' => '-5',
-  );
-  $export['content_access_document'] = $strongarm;
 
   $strongarm = new stdClass();
   $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */


### PR DESCRIPTION
Added a Strongarm variable setting to set default permissions for new Documents.  I think this was the right place to add it; when I tried instead changing the global lacuna_stories_system feature settings contained in the "_user_default_permissions function in the ".features.user_permissions.inc file seemed to work at first, but I found it was letting through any authenticated user, not respecting the OG membership rules.  This fix does respect those rules: authenticated users not enrolled in a course still can't see that course's materials.