### PR TITLE
Draggable views fix

### DIFF
--- a/misc/tabledrag.js
+++ b/misc/tabledrag.js
@@ -580,12 +580,20 @@ Drupal.tableDrag.prototype.dropRow = function (event, self) {
  * Get the mouse coordinates from the event (allowing for browser differences).
  */
 Drupal.tableDrag.prototype.mouseCoords = function (event) {
+  // Complete support for pointer events was only introduced to jQuery in
+  // version 1.11.1; between versions 1.7 and 1.11.0 pointer events have the
+  // clientX and clientY properties undefined. In those cases, the properties
+  // must be retrieved from the event.originalEvent object instead.
+  var clientX = event.clientX || event.originalEvent.clientX;
+  var clientY = event.clientY || event.originalEvent.clientY;
+
   if (event.pageX || event.pageY) {
     return { x: event.pageX, y: event.pageY };
   }
+
   return {
-    x: event.clientX + document.body.scrollLeft - document.body.clientLeft,
-    y: event.clientY + document.body.scrollTop  - document.body.clientTop
+    x: clientX + document.body.scrollLeft - document.body.clientLeft,
+    y: clientY + document.body.scrollTop  - document.body.clientTop
   };
 };
 

--- a/sites/all/modules/custom/sewing_kit/lacuna_stories_threads/lacuna_stories_threads.views_default.inc
+++ b/sites/all/modules/custom/sewing_kit/lacuna_stories_threads/lacuna_stories_threads.views_default.inc
@@ -571,7 +571,8 @@ if (module_exists(\'course\')) {
   $handler->display->display_options['pager']['options']['offset'] = '0';
   $handler->display->display_options['style_plugin'] = 'table';
   $handler->display->display_options['style_options']['columns'] = array(
-    'draggableviews' => 'draggableviews',
+    'views_bulk_operations' => 'views_bulk_operations',
+    'nid_1' => 'nid_1',
     'name' => 'name',
     'field_annotation_reference' => 'field_annotation_reference',
     'field_annotation_quote' => 'field_annotation_quote',
@@ -581,23 +582,32 @@ if (module_exists(\'course\')) {
     'nid' => 'nid',
     'path' => 'path',
     'nothing' => 'nothing',
+    'draggableviews' => 'draggableviews',
+    'weight' => 'weight',
   );
-  $handler->display->display_options['style_options']['default'] = 'field_annotation_reference';
+  $handler->display->display_options['style_options']['default'] = 'weight';
   $handler->display->display_options['style_options']['info'] = array(
-    'draggableviews' => array(
+    'views_bulk_operations' => array(
+      'align' => '',
+      'separator' => '',
+      'empty_column' => 0,
+    ),
+    'nid_1' => array(
+      'sortable' => 0,
+      'default_sort_order' => 'asc',
       'align' => '',
       'separator' => '',
       'empty_column' => 0,
     ),
     'name' => array(
-      'sortable' => 1,
+      'sortable' => 0,
       'default_sort_order' => 'asc',
       'align' => '',
       'separator' => '',
       'empty_column' => 0,
     ),
     'field_annotation_reference' => array(
-      'sortable' => 1,
+      'sortable' => 0,
       'default_sort_order' => 'asc',
       'align' => '',
       'separator' => '',
@@ -618,7 +628,7 @@ if (module_exists(\'course\')) {
       'empty_column' => 0,
     ),
     'field_annotation_category' => array(
-      'sortable' => 1,
+      'sortable' => 0,
       'default_sort_order' => 'asc',
       'align' => '',
       'separator' => '',
@@ -642,6 +652,18 @@ if (module_exists(\'course\')) {
       'empty_column' => 0,
     ),
     'nothing' => array(
+      'align' => '',
+      'separator' => '',
+      'empty_column' => 0,
+    ),
+    'draggableviews' => array(
+      'align' => '',
+      'separator' => '',
+      'empty_column' => 0,
+    ),
+    'weight' => array(
+      'sortable' => 1,
+      'default_sort_order' => 'asc',
       'align' => '',
       'separator' => '',
       'empty_column' => 0,
@@ -926,6 +948,11 @@ if (module_exists(\'course\')) {
   $handler->display->display_options['fields']['draggableviews']['element_default_classes'] = FALSE;
   $handler->display->display_options['fields']['draggableviews']['hide_alter_empty'] = FALSE;
   $handler->display->display_options['fields']['draggableviews']['draggableviews']['ajax'] = 1;
+  /* Field: Draggableviews: Weight */
+  $handler->display->display_options['fields']['weight']['id'] = 'weight';
+  $handler->display->display_options['fields']['weight']['table'] = 'draggableviews_structure';
+  $handler->display->display_options['fields']['weight']['field'] = 'weight';
+  $handler->display->display_options['fields']['weight']['exclude'] = TRUE;
 
   /* Display: Doc Data export */
   $handler = $view->new_display('views_data_export', 'Doc Data export', 'views_data_export_1');

--- a/sites/all/modules/patches/core/pointereventfix-2821441-30.patch
+++ b/sites/all/modules/patches/core/pointereventfix-2821441-30.patch
@@ -1,0 +1,27 @@
+diff --git a/misc/tabledrag.js b/misc/tabledrag.js
+index 4e07784..7ea88b6 100644
+--- a/misc/tabledrag.js
++++ b/misc/tabledrag.js
+@@ -580,12 +580,20 @@ Drupal.tableDrag.prototype.dropRow = function (event, self) {
+  * Get the mouse coordinates from the event (allowing for browser differences).
+  */
+ Drupal.tableDrag.prototype.mouseCoords = function (event) {
++  // Complete support for pointer events was only introduced to jQuery in
++  // version 1.11.1; between versions 1.7 and 1.11.0 pointer events have the
++  // clientX and clientY properties undefined. In those cases, the properties
++  // must be retrieved from the event.originalEvent object instead.
++  var clientX = event.clientX || event.originalEvent.clientX;
++  var clientY = event.clientY || event.originalEvent.clientY;
++
+   if (event.pageX || event.pageY) {
+     return { x: event.pageX, y: event.pageY };
+   }
++
+   return {
+-    x: event.clientX + document.body.scrollLeft - document.body.clientLeft,
+-    y: event.clientY + document.body.scrollTop  - document.body.clientTop
++    x: clientX + document.body.scrollLeft - document.body.clientLeft,
++    y: clientY + document.body.scrollTop  - document.body.clientTop
+   };
+ };
+ 


### PR DESCRIPTION
Applied patch to fix DraggableViews in Chrome, and removed sorting options in the Stitchings table of a Thread so they're always sorted by DraggableViews weight, so dragged changes will now stick.